### PR TITLE
Feat/update aws lib

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import os
 
-from aws_cdk import core as cdk
+import aws_cdk as cdk
 
 from yearn_gnosis_safe.yearn_gnosis_safe_stack import YearnGnosisSafeStack
 

--- a/cdk.json
+++ b/cdk.json
@@ -16,13 +16,9 @@
   },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": true,
     "aws-cdk:enableDiffNoFail": true,
     "@aws-cdk/core:stackRelativeExports": true,
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
     "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
     "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
     "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,

--- a/erigon_app.py
+++ b/erigon_app.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import os
 
-from aws_cdk import core as cdk
+import aws_cdk as cdk
 from aws_cdk import aws_ec2 as ec2
+from constructs import Construct
 
 from yearn_gnosis_safe.erigon_stack import ErigonEthereumStack
 
@@ -10,7 +11,7 @@ app = cdk.App()
 
 
 class AppStack(cdk.Stack):
-    def __init__(self, scope: cdk.Construct, id: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
         vpc_id = os.environ.get("CDK_DEPLOY_VPC")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,1 @@
-aws-cdk.core>=1.133.0
-aws-cdk.assertions>=1.133.0
-aws-cdk.aws-ecs>=1.133.0
-aws-cdk.aws-ecs-patterns>=1.133.0
-aws-cdk.aws-ec2>=1.133.0
-aws-cdk.aws-rds>=1.133.0
-aws-cdk.aws-secretsmanager>=1.133.0
-aws-cdk.aws-elasticache>=1.133.0
-aws-cdk.aws-elasticloadbalancingv2>=1.133.0
-aws-cdk.aws-s3>=1.133.0
-aws-cdk.aws-s3-deployment>=1.133.0
+aws-cdk-lib>=2.83.0

--- a/yearn_gnosis_safe/erigon_stack.py
+++ b/yearn_gnosis_safe/erigon_stack.py
@@ -3,7 +3,8 @@ from aws_cdk import aws_ecs as ecs
 from aws_cdk import aws_elasticloadbalancingv2 as elbv2
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_logs as logs
-from aws_cdk import core as cdk
+import aws_cdk as cdk
+from constructs import Construct
 
 from yearn_gnosis_safe.gnosis_safe_shared_stack import GnosisSafeSharedStack
 
@@ -11,7 +12,7 @@ from yearn_gnosis_safe.gnosis_safe_shared_stack import GnosisSafeSharedStack
 class ErigonEthereumStack(cdk.Stack):
     def __init__(
         self,
-        scope: cdk.Construct,
+        scope: Construct,
         construct_id: str,
         vpc: ec2.Vpc,
         chain_name: str = "rinkeby",

--- a/yearn_gnosis_safe/gnosis_safe_client_gateway_stack.py
+++ b/yearn_gnosis_safe/gnosis_safe_client_gateway_stack.py
@@ -1,8 +1,9 @@
 from typing import Optional
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecs as ecs
-from aws_cdk import core as cdk
+import aws_cdk as cdk
 from aws_cdk import aws_elasticloadbalancingv2 as elbv2
+from constructs import Construct
 
 from yearn_gnosis_safe.gnosis_safe_shared_stack import GnosisSafeSharedStack
 from yearn_gnosis_safe.redis_stack import RedisStack
@@ -15,7 +16,7 @@ class GnosisSafeClientGatewayStack(cdk.Stack):
 
     def __init__(
         self,
-        scope: cdk.Construct,
+        scope: Construct,
         construct_id: str,
         vpc: ec2.IVpc,
         shared_stack: GnosisSafeSharedStack,

--- a/yearn_gnosis_safe/gnosis_safe_configuration_stack.py
+++ b/yearn_gnosis_safe/gnosis_safe_configuration_stack.py
@@ -3,7 +3,8 @@ from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecs as ecs
 from aws_cdk import aws_elasticloadbalancingv2 as elbv2
 from aws_cdk import aws_rds as rds
-from aws_cdk import core as cdk
+import aws_cdk as cdk
+from constructs import Construct
 
 from yearn_gnosis_safe.gnosis_safe_shared_stack import GnosisSafeSharedStack
 
@@ -15,7 +16,7 @@ class GnosisSafeConfigurationStack(cdk.Stack):
 
     def __init__(
         self,
-        scope: cdk.Construct,
+        scope: Construct,
         construct_id: str,
         vpc: ec2.IVpc,
         shared_stack: GnosisSafeSharedStack,

--- a/yearn_gnosis_safe/gnosis_safe_shared_stack.py
+++ b/yearn_gnosis_safe/gnosis_safe_shared_stack.py
@@ -5,7 +5,8 @@ from aws_cdk import aws_elasticloadbalancingv2 as elbv2
 from aws_cdk import aws_logs as logs
 from aws_cdk import aws_rds as rds
 from aws_cdk import aws_secretsmanager as secretsmanager
-from aws_cdk import core as cdk
+import aws_cdk as cdk
+from constructs import Construct
 
 
 class GnosisSafeSharedStack(cdk.Stack):
@@ -43,7 +44,7 @@ class GnosisSafeSharedStack(cdk.Stack):
 
     def __init__(
         self,
-        scope: cdk.Construct,
+        scope: Construct,
         construct_id: str,
         vpc: ec2.IVpc,
         **kwargs,

--- a/yearn_gnosis_safe/gnosis_safe_transaction_stack.py
+++ b/yearn_gnosis_safe/gnosis_safe_transaction_stack.py
@@ -3,8 +3,9 @@ from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecs as ecs
 from aws_cdk import aws_elasticloadbalancingv2 as elbv2
 from aws_cdk import aws_rds as rds
-from aws_cdk import core as cdk
+import aws_cdk as cdk
 from jsii import Number
+from constructs import Construct
 
 from yearn_gnosis_safe.gnosis_safe_shared_stack import GnosisSafeSharedStack
 from yearn_gnosis_safe.redis_stack import RedisStack
@@ -17,7 +18,7 @@ class GnosisSafeTransactionStack(cdk.Stack):
 
     def __init__(
         self,
-        scope: cdk.Construct,
+        scope: Construct,
         construct_id: str,
         vpc: ec2.IVpc,
         shared_stack: GnosisSafeSharedStack,

--- a/yearn_gnosis_safe/gnosis_safe_ui_stack.py
+++ b/yearn_gnosis_safe/gnosis_safe_ui_stack.py
@@ -1,8 +1,9 @@
 from typing import Optional, Sequence
 from aws_cdk import aws_ec2 as ec2
-from aws_cdk import core as cdk
+import aws_cdk as cdk
 from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_s3_deployment as s3_deployment
+from constructs import Construct
 
 from yearn_gnosis_safe.gnosis_safe_shared_stack import GnosisSafeSharedStack
 
@@ -10,7 +11,7 @@ from yearn_gnosis_safe.gnosis_safe_shared_stack import GnosisSafeSharedStack
 class GnosisSafeUIStack(cdk.Stack):
     def __init__(
         self,
-        scope: cdk.Construct,
+        scope: Construct,
         construct_id: str,
         environment_name: str,
         shared_stack: GnosisSafeSharedStack,

--- a/yearn_gnosis_safe/redis_stack.py
+++ b/yearn_gnosis_safe/redis_stack.py
@@ -1,14 +1,15 @@
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_elasticache as elasticache
-from aws_cdk import core as cdk
+import aws_cdk as cdk
+from constructs import Construct
 
 
-class RedisStack(cdk.Construct):
+class RedisStack(Construct):
     @property
     def connections(self):
         return self._connections
 
-    def __init__(self, scope: cdk.Construct, id: str, vpc: ec2.IVpc, cache_node_type: str="cache.t3.small") -> None:
+    def __init__(self, scope: Construct, id: str, vpc: ec2.IVpc, cache_node_type: str="cache.t3.small") -> None:
         super().__init__(scope, id)
 
         sg_elasticache = ec2.SecurityGroup(

--- a/yearn_gnosis_safe/yearn_gnosis_safe_stack.py
+++ b/yearn_gnosis_safe/yearn_gnosis_safe_stack.py
@@ -1,6 +1,7 @@
 from typing import Optional, Union
 from aws_cdk import aws_ec2 as ec2
-from aws_cdk import core as cdk
+import aws_cdk as cdk
+from constructs import Construct
 
 from yearn_gnosis_safe.gnosis_safe_client_gateway_stack import \
     GnosisSafeClientGatewayStack
@@ -15,7 +16,7 @@ from yearn_gnosis_safe.gnosis_safe_ui_stack import GnosisSafeUIStack
 class YearnGnosisSafeStack(cdk.Stack):
     def __init__(
         self,
-        scope: cdk.Construct,
+        scope: Construct,
         construct_id: str,
         environment_name: str,
         ui_subdomain: Union[str, None],


### PR DESCRIPTION
aws cdk v1.* deprecated
This commits update infrastructure to aws-lib v.2.83.0 and rewrite some imports in python scripts  